### PR TITLE
TASK | Make lbfgs task tests more robust

### DIFF
--- a/test/prediction/trainer_logistic_loss_with_l2_test.py
+++ b/test/prediction/trainer_logistic_loss_with_l2_test.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 from prediction.fixtures import generate_mock_training_data, simple_mock_data
 from test_utils import (PLACES_PRECISION, matrices_almost_equal,
-                        sequences_almost_equal)
+                        sequences_almost_equal, ensure_str)
 
 from linkedin.learner.ds.indexed_model import IndexedModel
 from linkedin.learner.prediction.evaluator import evaluate
@@ -61,7 +61,7 @@ class TrainerLogisticLossWithL2Test(unittest.TestCase):
         self.assertEqual(metadata["warnflag"], 0, "Expect convergence status is 0, meaning successful convergence.")
         self.assertEqual(metadata["nit"], 13, "Expect number of iterations is correct.")
         self.assertEqual(metadata["funcalls"], 18, "Expect number of function calls is correct.")
-        self.assertEqual(metadata["task"], b"CONVERGENCE: NORM_OF_PROJECTED_GRADIENT_<=_PGTOL", f"Expect convergence reason is as expected")
+        self.assertEqual(ensure_str(metadata["task"]), "CONVERGENCE: NORM_OF_PROJECTED_GRADIENT_<=_PGTOL", f"Expect convergence reason is as expected")
 
         # Score (on the training data)
         initial_scores = score_linear_model(model=initial_model, test_data=indexed_data)

--- a/test/prediction/trainer_sequential_bayesian_logistic_loss_with_l2_test.py
+++ b/test/prediction/trainer_sequential_bayesian_logistic_loss_with_l2_test.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 from prediction.fixtures import generate_mock_training_data, simple_mock_data
 from test_utils import (PLACES_PRECISION, matrices_almost_equal,
-                        sequences_almost_equal)
+                        sequences_almost_equal, ensure_str)
 
 from linkedin.learner.ds.indexed_model import IndexedModel
 from linkedin.learner.prediction.evaluator import evaluate
@@ -64,7 +64,7 @@ class TrainerSequentialBayesianLogisticLossWithL2Test(unittest.TestCase):
         self.assertEqual(metadata["warnflag"], 0, "Expect convergence status is 0, meaning successful convergence.")
         self.assertEqual(metadata["nit"], 20, "Expect number of iterations is correct.")
         self.assertEqual(metadata["funcalls"], 28, "Expect number of function calls is correct.")
-        self.assertEqual(metadata["task"], b"CONVERGENCE: REL_REDUCTION_OF_F_<=_FACTR*EPSMCH", f"Expect convergence reason is as expected")
+        self.assertEqual(ensure_str(metadata["task"]), "CONVERGENCE: REL_REDUCTION_OF_F_<=_FACTR*EPSMCH", f"Expect convergence reason is as expected")
 
         # Score (on the training data)
         initial_scores = score_linear_model(model=initial_model, test_data=indexed_data)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -23,3 +23,10 @@ def matrices_almost_equal(a, b, rel_precision: float = RELATIVE_PRECISION):
     """
     zero_adjustment = ((b == 0) + 0) * (rel_precision / 1000)
     return all((np.array(abs(1 - (a + zero_adjustment) / (b + zero_adjustment)) < rel_precision)).flatten())
+
+
+def ensure_str(bytes_or_str, encoding: str = "utf-8"):
+    """
+    Ensures that an object which is either a string or bytes is treated as a string.
+    """
+    return str(bytes_or_str, encoding) if isinstance(bytes_or_str, bytes) else bytes_or_str


### PR DESCRIPTION
In tests for `metadata['task']`, this value was turning up as different types (str vs bytes) in different environments, possibly due to different scipy versions. This RB makes the tests work for either type, since the type is irrelevant to what we are testing for.